### PR TITLE
Feature: add seed option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2020-06-14
+### Added
+- A `seed:` keyword argument for `Stroop::Set#initialize`
+- `--seed`/`-s` CLI option to pass a random seed which is used to generate the color words
+
 ## [1.0.0] - 2020-05-21
 ### Removed 
 - Drop support for Ruby <= v2.4
@@ -22,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Inital release
 
-[Unreleased]: https://github.com/paulgoetze/stroop/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/paulgoetze/stroop/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/paulgoetze/stroop/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/paulgoetze/stroop/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/paulgoetze/stroop/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ This will print you a Stroop test of 10 lines of words with 5 words in each of t
 
 You can adjust the rows and columns of words by changing the `CxR` param as you like (e.g. `5x2`). If you leave it out a default of `5x10` is used.
 
+For each print out you will find the random seed that was used to generate the color words.
+
+You can also pass a seed by using the `--seed` or `-s` option:
+
+```bash
+$ stroop neutral --seed=1234 
+$ stroop congruent -s 1234 
+$ stroop incongruent -s 1234
+```
+
 If you want to use Stroop in Ruby you can run the following code:
 
 ```ruby
@@ -47,6 +57,10 @@ require 'stroop'
 # adjust rows and columns to whatever you like
 set = Stroop::Set.new(columns: 5, rows: 10, mode: Stroop::Set::NEUTRAL)
 set.to_s # => returns the string of colorized words
+
+# or if you want to pass a specific random seed that is used to generate the set:
+set = Stroop::Set.new(columns: 5, rows: 10, mode: Stroop::Set::NEUTRAL, seed: 1234)
+set.seed # => returns the random seed that was used to create the color words
 ```
 
 The available Stroop::Set modes are:

--- a/lib/stroop/cli.rb
+++ b/lib/stroop/cli.rb
@@ -5,29 +5,32 @@ module Stroop
   class CLI < Thor
     DEFAULT_SIZE = 5.freeze
 
+    class_option :seed, type: :numeric, aliases: "-s", description: "The random seed to generate the color words"
+
     desc 'neutral COLSxROWS', 'prints neutral color words in COLS columns and ROWS rows'
     def neutral(size = '10x5')
-      print(size: size, mode: Set::NEUTRAL)
+      print(size: size, mode: Set::NEUTRAL, seed: options[:seed])
     end
 
     desc 'congruent COLSxROWS', 'prints congruent color words in COLS columns and ROWS rows'
     def congruent(size = '10x5')
-      print(size: size, mode: Set::CONGRUENT)
+      print(size: size, mode: Set::CONGRUENT, seed: options[:seed])
     end
 
     desc 'incongruent COLSxROWS', 'prints incongruent color words in COLS columns and ROWS rows'
     def incongruent(size = '10x5')
-      print(size: size, mode: Set::INCONGRUENT)
+      print(size: size, mode: Set::INCONGRUENT, seed: options[:seed])
     end
 
     private
 
-    def print(size:, mode:)
+    def print(size:, mode:, seed:)
       rows, columns = dimensions(size)
       rows          = apply_default_size(rows)
       columns       = apply_default_size(columns)
 
-      puts Set.new(rows: rows, columns: columns, mode: mode).to_s
+      set = Stroop::Set.new(rows: rows, columns: columns, mode: mode, seed: seed)
+      puts set, "🌱 Generated with seed: #{set.seed}"
     end
 
     def dimensions(size)

--- a/lib/stroop/color_generator.rb
+++ b/lib/stroop/color_generator.rb
@@ -1,0 +1,41 @@
+module Stroop
+  class ColorGenerator
+    COLORS = %w{ black white red green blue yellow }.freeze
+
+    attr_reader :seed
+
+    def initialize(seed: nil)
+      @seed = seed || Random.new_seed
+      @single_random = Random.new(@seed)
+      @pair_random = Random.new(@seed)
+    end
+
+    def generate
+      selected = random_select(@single_random)
+
+      while selected == @last_generated do
+        selected = random_select(@single_random)
+      end
+
+      @last_generated = selected
+    end
+
+    def generate_pair
+      first = generate
+      second = random_select(@pair_random)
+
+      while first == second || second == @last_generated_second do
+        second = random_select(@pair_random)
+      end
+
+      @last_generated_second = second
+      [first, second]
+    end
+
+    private
+
+    def random_select(random)
+      COLORS.sample(random: random)
+    end
+  end
+end

--- a/lib/stroop/version.rb
+++ b/lib/stroop/version.rb
@@ -1,5 +1,5 @@
 module Stroop
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,15 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'stroop'
+
+def capture(stream)
+  begin
+    stream = stream.to_s
+    eval "$#{stream} = StringIO.new"
+    yield
+    result = eval("$#{stream}").string
+  ensure
+    eval("$#{stream} = #{stream.upcase}")
+  end
+
+  result
+end

--- a/spec/stroop/cli_spec.rb
+++ b/spec/stroop/cli_spec.rb
@@ -1,32 +1,35 @@
 require 'spec_helper'
 
 describe Stroop::CLI do
+  let(:seed) { 1234 }
 
   before do
+    allow_any_instance_of(Stroop::Set).to receive(:seed) { seed }
     allow_any_instance_of(Stroop::Set).to receive(:to_s) { '' }
     allow($stdout).to receive(:puts) { '' }
   end
+
+  subject { described_class.new([seed]) }
 
   [:neutral, :congruent, :incongruent].each do |method|
     it { is_expected.to respond_to method }
 
     describe "##{method}" do
-      let(:size) { '1x1' }
+      let(:columns) { 1 }
+      let(:rows) { 1 }
+      let(:args) { "#{columns}x#{rows}" }
 
-      it 'should create a new Stroop::Set' do
-        expect(Stroop::Set).to receive(:new).once
-        subject.send(method, size)
+      it 'prints to the standard output' do
+        expect { subject.send(method, args) }.to output.to_stdout
       end
 
-      it 'should convert the Stroop::Set to a string' do
-        expect_any_instance_of(Stroop::Set).to receive(:to_s).once
-        subject.send(method, size)
-      end
+      it 'prints the stroop set' do
+        set = Stroop::Set.new(columns: columns, rows: rows, mode: method, seed: seed)
+        output = capture(:stdout) { subject.send(method, args) }
 
-      it 'should print to the standard output' do
-        expect { subject.send(method, size) }.to output.to_stdout
+        expect(output).to include set.to_s
+        expect(output).to include "Generated with seed: #{seed}"
       end
     end
   end
-
 end

--- a/spec/stroop/color_generator_spec.rb
+++ b/spec/stroop/color_generator_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe Stroop::ColorGenerator do
+  describe 'without seed' do
+    subject { described_class.new }
+
+    describe '#generate' do
+      it 'returns a random color' do
+        expect(Stroop::ColorGenerator::COLORS).to include subject.generate
+      end
+    end
+
+    describe '#generate_pair' do
+      it 'returns a pair of colors that are different' do
+        20.times do
+          first, second = subject.generate_pair
+          expect(first).to_not eq second
+        end
+      end
+
+      it 'returns another pair in subsequent calls' do
+        previous_colors = subject.generate_pair
+
+        20.times do
+          new_colors = subject.generate_pair
+          expect(new_colors).to_not eq previous_colors
+          previous_colors = new_colors
+        end
+      end
+    end
+
+    describe 'with seed' do
+      let(:seed) { 1234 }
+      let(:generator) { described_class.new(seed: seed) }
+      let(:other_generator) { described_class.new(seed: seed) }
+
+      describe '#generate' do
+        it 'uses the given seed to generate colors deterministically' do
+          20.times { expect(generator.generate).to eq other_generator.generate }
+        end
+      end
+
+      describe '#generate_pair' do
+        it 'uses the given seed to generate colors deterministically' do
+          20.times { expect(generator.generate_pair).to eq other_generator.generate_pair }
+        end
+      end
+
+      it 'generates the same colors for #generate and #generate_pair (first color only)' do
+        generated_colors = 20.times.map { generator.generate }
+        generated_pairs_first_colors = 20.times.map { other_generator.generate_pair.first }
+
+        expect(generated_colors).to eq generated_pairs_first_colors
+      end
+    end
+  end
+end

--- a/spec/stroop/set_spec.rb
+++ b/spec/stroop/set_spec.rb
@@ -1,51 +1,82 @@
 require 'spec_helper'
 
 describe Stroop::Set do
+  [:neutral, :incongruent, :congruent].each do |mode|
+    let(:arguments) { {rows: 1, columns: 2, mode: mode } }
+    subject { described_class.new(**arguments) }
 
-  let(:arguments) { {rows: 1, columns: 2, mode: :neutral } }
-  subject { described_class.new(**arguments) }
+    describe 'creating a new instance' do
+      it 'raises an error if the given mode is not available' do
+        expect {
+          described_class.new(**arguments.merge({ mode: :not_existing }))
+        }.to raise_error Stroop::SetModeNotAvailable
+      end
 
-  describe 'creating a new instance' do
-    it 'should raise an error if the given mode is not available' do
-      expect {
-        described_class.new(**arguments.merge({ mode: :not_existing }))
-      }.to raise_error Stroop::SetModeNotAvailable
+      it 'does not raise an error if the given mode is available' do
+        expect {
+          described_class.new(**arguments.merge({ mode: :neutral }))
+          described_class.new(**arguments.merge({ mode: :congruent }))
+          described_class.new(**arguments.merge({ mode: :incongruent }))
+        }.not_to raise_error
+      end
     end
 
-    it 'should not raise an error if the given mode is available' do
-      expect {
-        described_class.new(**arguments.merge({ mode: :neutral }))
-        described_class.new(**arguments.merge({ mode: :congruent }))
-        described_class.new(**arguments.merge({ mode: :incongruent }))
-      }.not_to raise_error
+    [:NEUTRAL, :CONGRUENT, :INCONGRUENT, :MODES].each do |name|
+      it "has a constant '#{name}'" do
+        expect(described_class.constants).to include name
+      end
+    end
+
+    [:rows, :columns, :mode, :seed].each do |method|
+      it "responds to ##{method}" do
+        expect(subject).to respond_to method
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns a text with the instantiated number of lines' do
+        actual_rows   = subject.to_s.lines.count
+        expected_rows = subject.rows + 2 # 2 wrapping empty lines (first & last)
+
+        expect(actual_rows).to eq expected_rows
+      end
+
+      it 'returns a text with the defined number of words per line' do
+        color_regex = /(#{Stroop::ColorGenerator::COLORS.join('|')})/
+        line        = subject.to_s.lines[1] # first line with words
+        words       = line.scan(color_regex).flatten
+
+        expect(words.count).to eq subject.columns
+      end
+
+      it 'returns the same text for the same seed' do
+        args = arguments.merge(seed: 1234)
+        set = described_class.new(**args)
+        other_set = described_class.new(**args)
+
+        expect(set.to_s).to eq other_set.to_s
+      end
+
+      it 'returns different texts for the different seeds' do
+        set = described_class.new(**arguments.merge(seed: 1))
+        other_set = described_class.new(**arguments.merge(seed: 2))
+
+        expect(set.to_s).to_not eq other_set.to_s
+      end
+    end
+
+    describe '#seed' do
+      it 'returns the seed the set was initialized with' do
+        seed = Random.rand(100)
+        args = arguments.merge(seed: seed)
+        expect(described_class.new(**args).seed).to eq seed
+      end
+
+      it "returns a random seed if none was given" do
+        set = described_class.new(**arguments)
+        expect(set.seed).to_not be_nil
+        expect(set.seed).to be_a Integer
+      end
     end
   end
-
-  [:NEUTRAL, :CONGRUENT, :INCONGRUENT, :COLORS, :MODES].each do |name|
-    it "should have a constant '#{name}'" do
-      expect(described_class.constants).to include name
-    end
-  end
-
-  [:rows, :columns, :mode].each do |method|
-    it "should respond to ##{method}" do
-      expect(subject).to respond_to method
-    end
-  end
-
-  it 'should return a text with the instantiated number of lines' do
-    actual_rows   = subject.to_s.lines.count
-    expected_rows = subject.rows + 2 # 2 wrapping empty lines (first & last)
-
-    expect(actual_rows).to eq expected_rows
-  end
-
-  it 'should return a text with the defined number of words per line' do
-    color_regex = /(#{described_class::COLORS.join('|')})/
-    line        = subject.to_s.lines[1] # first line with words
-    words       = line.scan(color_regex).flatten
-
-    expect(words.count).to eq subject.columns
-  end
-
 end


### PR DESCRIPTION
* Allow passing a random seed via the `--seed`/`-s` CLI option.
* Display the used random seed for each run.

This allows printing the same color words in different modi instead of getting other random words for each run.